### PR TITLE
Fix servo controller reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Installation des paquets non disponibles via apt avec pip
 ### Montage des servomoteurs et installation audio
 
 -   **Installation des haut-parleurs**: Montez un haut-parleur de 18,5 watts sur le côté de la tête pour la diffusion du son. Amplifiez le signal audio provenant du Raspberry Pi avec un amplificateur PAM8403.
--   **Servomoteurs**: Placez trois servomoteurs – deux SD9D pour les bras et un Engin ID pour la rotation du corps. Utilisez un contrôleur PC9685 pour une gestion aisée des servomoteurs.
+-   **Servomoteurs**: Placez trois servomoteurs – deux SD9D pour les bras et un Engin ID pour la rotation du corps. Utilisez un contrôleur PCA9685 pour une gestion aisée des servomoteurs.
 
 ### Assemblage final et tests
 


### PR DESCRIPTION
## Summary
- correct typo for PCA9685 servo controller in README

## Testing
- `grep -n "PCA9685" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_68413c8322308326b2e89ce78fe8a6fa