### PR TITLE
Fix process initialization

### DIFF
--- a/Code/final.py
+++ b/Code/final.py
@@ -241,9 +241,12 @@ if __name__ == '__main__':
     p1 = multiprocessing.Process(target=check_sensor, name='p1')
     p1.start()
     bootup()
+    p5 = None
+    p6 = None
     while True:
         if event.is_set():
-                p5.terminate()
+                if p5 is not None:
+                    p5.terminate()
                 event.clear()
                 emotion = q.get()
                 q.empty()


### PR DESCRIPTION
## Summary
- set `p5` and `p6` to `None` before the main loop
- guard `p5.terminate()` to avoid calling on an undefined process

## Testing
- `python3 -m py_compile Code/final.py`

------
https://chatgpt.com/codex/tasks/task_e_68413c817f048326a924b9d48792e7dc