### PR TITLE
Clean up unused imports

### DIFF
--- a/Code/final.py
+++ b/Code/final.py
@@ -1,20 +1,15 @@
 import time
-from board import SCL, SDA
-import busio
 from adafruit_servokit import ServoKit
 import multiprocessing
 
 import RPi.GPIO as GPIO
 import os
-
-import os
-import sys 
-import time
+import sys
 import logging
 import spidev as SPI
 sys.path.append("..")
 from lib import LCD_2inch
-from PIL import Image,ImageDraw,ImageFont
+from PIL import Image
 
 from random import randint
 


### PR DESCRIPTION
## Summary
- remove duplicate `os` and `time` imports
- drop unused `board`, `busio`, `ImageDraw`, and `ImageFont` imports

## Testing
- `python -m py_compile Code/final.py`

------
https://chatgpt.com/codex/tasks/task_e_68413c5776fc8326abc9ced82d881bbc